### PR TITLE
Fix getDevices api request

### DIFF
--- a/src/myq.js
+++ b/src/myq.js
@@ -181,9 +181,9 @@ class MyQ {
     return axios({
       method: 'get',
       url: `${constants.endpoint}/api/v4/userdevicedetails/get`,
-      params: {
-        appId: constants.appId,
-        SecurityToken: this.securityToken,
+      headers: {
+        MyQApplicationId: constants.appId,
+        securityToken: this.securityToken,
       },
     })
       .then(response => {


### PR DESCRIPTION
It looks like MyQ updated the GET endpoint and moved the security token from the params to the headers.