### PR TITLE
Fix/get devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "axios": "0.18.0"
+    "axios": "^0.19.1"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/myq.js
+++ b/src/myq.js
@@ -167,7 +167,7 @@ class MyQ {
   getDevices(typeIdParams) {
     if (!this.securityToken) {
       return Promise.resolve(returnError(13));
-    } else if (typeIdParams === null) {
+    } else if (!typeIdParams) {
       return Promise.resolve(returnError(15));
     }
 
@@ -176,7 +176,7 @@ class MyQ {
     for (let i = 0; i < typeIds.length; i += 1) {
       const typeId = typeIds[i];
       if (!constants.allTypeIds.includes(typeId)) {
-        return returnError(15);
+        return Promise.resolve(returnError(15));
       }
     }
 


### PR DESCRIPTION
`getDevices` call should always return a promise. i.e. when calling without parameters, `getDevices` will return a json object instead of a promise with the json object

Changes:
- upgrades axios to 0.19.1 from `npm audit fix`
- handles empty arguments in `getDevices` call
- returns a promise when typeId validation fails 