### PR TITLE
Fix ability to get devices by type

### DIFF
--- a/src/myq.js
+++ b/src/myq.js
@@ -160,7 +160,7 @@ class MyQ {
       .catch(({ response }) => ErrorHandler.parseBadResponse(response));
   }
 
-  getDevices() {
+  getDevices(types) {
     let promise = Promise.resolve();
     if (!this.accountId) {
       promise = this.getAccountInfo();
@@ -192,7 +192,15 @@ class MyQ {
         };
 
         const modifiedDevices = [];
-        Object.values(devices).forEach(device => {
+        let devicesToIterate = Object.values(devices);
+        if (types) {
+          if (Array.isArray(types)) {
+            devicesToIterate = devicesToIterate.filter(device => types.some(type => type === device.device_type));
+          } else if (typeof types === 'string') {
+            devicesToIterate = devicesToIterate.filter(device => types === device.device_type);
+          }
+        }
+        devicesToIterate.forEach(device => {
           const modifiedDevice = {
             family: device.device_family,
             name: device.name,


### PR DESCRIPTION
This now properly filters down devices based on a given type whether given `getDevices(constants.allDeviceTypes.virtualGarageDoorOpener)` or as an array `getDevices([constants.allDeviceTypes.virtualGarageDoorOpener])`