### PR TITLE
Add GitHub workflows for running periodic and event-based tests and actions

### DIFF
--- a/.github/workflows/cron_e2e_test.yml
+++ b/.github/workflows/cron_e2e_test.yml
@@ -1,0 +1,22 @@
+name: Cron E2E Test
+
+on:
+  schedule:
+    # 8:12, 19:12 daily - inconspicuous times to hopefully prevent service from blocklisting the account
+    - cron: '12 8/11 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: Install modules
+      run: npm install
+    - name: Run E2E tests
+      run: npm run test:e2e
+      env:
+        MYQ_EMAIL: ${{ secret.MYQ_EMAIL }}
+        MYQ_PASSWORD: ${{ secret.MYQ_PASSWORD }}

--- a/.github/workflows/cron_test.yml
+++ b/.github/workflows/cron_test.yml
@@ -1,0 +1,22 @@
+name: Cron Test
+
+on:
+  schedule:
+    # 8:00 daily
+    - cron: '0 8 * * *'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '10.x', '12.x', '14.x' ]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install modules
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.github/workflows/on_update.yml
+++ b/.github/workflows/on_update.yml
@@ -1,0 +1,45 @@
+name: On Update
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ '10.x', '12.x', '14.x' ]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install modules
+      run: npm install
+    - name: Run tests
+      run: npm test
+  
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - name: Install modules
+      run: npm install
+    - name: Run tests with coverage
+      run: npm run test:coverage
+    - name: Upload to Coveralls
+      uses: coverallsapp/github-action@v1.1.1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run mutation testing and upload to Stryker
+      run: npm run test:mutants
+      env:
+        STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .stryker-tmp
+coverage
 reports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,6 +1684,19 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "coveralls": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.0.tgz",
+      "integrity": "sha512-sHxOu2ELzW8/NC1UP5XVLbZDzO4S3VxfFye3XYCznopHy02YjNkHcj5bKaVw2O7hVaBdBjEdQGpie4II1mWhuQ==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "3.14.0",
+        "lcov-parse": "1.0.0",
+        "log-driver": "1.2.7",
+        "minimist": "1.2.5",
+        "request": "2.88.2"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4226,6 +4239,12 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "lcov-parse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+      "integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
+      "dev": true
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -4292,6 +4311,12 @@
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
+    "log-driver": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
+      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
     "log4js": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "lint": "eslint --ignore-path .gitignore ./",
     "fix": "eslint --fix  --ignore-path .gitignore ./",
     "test": "jest test/unit",
+    "test:e2e": "jest test/e2e",
+    "test:coverage": "jest --coverage test/unit",
     "test:mutants": "stryker run"
   },
   "dependencies": {
@@ -46,6 +48,7 @@
     "@stryker-mutator/javascript-mutator": "^3.3.1",
     "@stryker-mutator/jest-runner": "^3.3.1",
     "axios-mock-adapter": "^1.18.2",
+    "coveralls": "^3.1.0",
     "eslint": "^7.7.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.11.0",
@@ -58,6 +61,6 @@
     "prettier": "^2.0.5"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=10"
   }
 }

--- a/stryker.conf.json
+++ b/stryker.conf.json
@@ -4,6 +4,10 @@
     "src/MyQ.js",
     "src/ErrorHandler.js"
   ],
+  "files": [
+    "src/**/*.js",
+    "test/unit/**/*.js"
+  ],
   "mutator": "javascript",
   "packageManager": "npm",
   "reporters": [

--- a/test/e2e/e2e.test.js
+++ b/test/e2e/e2e.test.js
@@ -1,0 +1,57 @@
+const MyQ = require('../../src/MyQ.js');
+
+test('login() fails when credentials are incorrect', async () => {
+  const account = new MyQ();
+  const promise = account.login('fake', 'fake');
+
+  await expect(promise).rejects.toMatchObject({
+    code: MyQ.constants.codes.AUTHENTICATION_FAILED,
+  });
+});
+
+test('login() succeeds when credentials are correct', async () => {
+  expect(process.env.MYQ_EMAIL).toBeDefined();
+  expect(process.env.MYQ_PASSWORD).toBeDefined();
+
+  const account = new MyQ();
+  const promise = account.login(process.env.MYQ_EMAIL, process.env.MYQ_PASSWORD);
+
+  await expect(promise).resolves.toEqual(
+    expect.objectContaining({
+      code: MyQ.constants.codes.OK,
+      securityToken: expect.any(String),
+    })
+  );
+});
+
+test('getAccountId() succeeds', async () => {
+  expect(process.env.MYQ_EMAIL).toBeDefined();
+  expect(process.env.MYQ_PASSWORD).toBeDefined();
+
+  const account = new MyQ();
+  await account.login(process.env.MYQ_EMAIL, process.env.MYQ_PASSWORD);
+  const promise = account._getAccountId();
+
+  await expect(promise).resolves.toEqual(
+    expect.objectContaining({
+      code: MyQ.constants.codes.OK,
+      accountId: expect.any(String),
+    })
+  );
+});
+
+test('getDevices() succeeds', async () => {
+  expect(process.env.MYQ_EMAIL).toBeDefined();
+  expect(process.env.MYQ_PASSWORD).toBeDefined();
+
+  const account = new MyQ();
+  await account.login(process.env.MYQ_EMAIL, process.env.MYQ_PASSWORD);
+  const promise = account.getDevices();
+
+  await expect(promise).resolves.toEqual(
+    expect.objectContaining({
+      code: MyQ.constants.codes.OK,
+      devices: expect.any(Array),
+    })
+  );
+});


### PR DESCRIPTION
These workflows include:
* a cron job that runs an E2E test with a test myQ account twice a day
* a cron job that runs the tests across supported node versions once a day
* a job to run the tests across supported node versions when master is
updated or a pull request is made to master
* a job to upload test health to Coveralls and Stryker when master is
updated or a pull request is made to master