### PR TITLE
Add type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "type": "git",
     "url": "git+https://github.com/thomasmunduchira/myq-api.git"
   },
+  "types": "types/index.d.ts",
   "scripts": {
     "lint": "eslint --ignore-path .gitignore ./",
     "fix": "eslint --fix  --ignore-path .gitignore ./",

--- a/types/MyQ.d.ts
+++ b/types/MyQ.d.ts
@@ -1,0 +1,151 @@
+import type {
+  DeviceResponse,
+  DeviceSetStateResponse,
+  DeviceStateResponse,
+  DevicesResponse,
+  LoginResponse,
+} from "./types";
+
+export default class MyQ {
+  /**
+   * Initialize the MyQ API.
+   *
+   * This used to take in an email and password, but these parameters have been deprecated in favor
+   * of login(username, password).
+   */
+  constructor();
+
+  /**
+   * Log into a myQ account and fetch a security token.
+   *
+   * This must be called before the rest of this API is called.  This used to take in no parameters,
+   * but the interface has been updated to take in the account email and password.
+   *
+   * Note that the security token is short-lived and will not work after some time, so this might
+   * have to be called again to retrieve a new security token.
+   *
+   * @param {string} email Email for the myQ account
+   * @param {string} password Password for the myQ account
+   * @returns {LoginResponse} containing a success code and security token
+   * @throws {MyQError} INVALID_ARGUMENT
+   * @throws {MyQError} SERVICE_REQUEST_FAILED
+   * @throws {MyQError} SERVICE_UNREACHABLE
+   * @throws {MyQError} INVALID_SERVICE_RESPONSE
+   * @throws {MyQError} AUTHENTICATION_FAILED
+   * @throws {MyQError} AUTHENTICATION_FAILED_ONE_TRY_LEFT
+   * @throws {MyQError} AUTHENTICATION_FAILED_LOCKED_OUT
+   */
+  public login(
+    username: string,
+    password: string
+  ): Promise<LoginResponse>;
+
+  /**
+   * Get the metadata and state of all devices on the myQ account.
+   *
+   * login() must be called before this.
+   *
+   * @returns {DevicesResponse} containing a success code and a list of devices
+   * @throws {MyQError} LOGIN_REQUIRED
+   * @throws {MyQError} SERVICE_REQUEST_FAILED
+   * @throws {MyQError} SERVICE_UNREACHABLE
+   * @throws {MyQError} INVALID_SERVICE_RESPONSE
+   */
+  public getDevices(): Promise<DevicesResponse>;
+
+  /**
+   * Get the metadata and state of a specific device on the myQ account.
+   *
+   * login() must be called before this.
+   *
+   * @param {string} serialNumber Serial number of device
+   * @returns {DeviceResponse} containing a success code and a list of devices
+   * @throws {MyQError} INVALID_ARGUMENT
+   * @throws {MyQError} LOGIN_REQUIRED
+   * @throws {MyQError} SERVICE_REQUEST_FAILED
+   * @throws {MyQError} SERVICE_UNREACHABLE
+   * @throws {MyQError} INVALID_SERVICE_RESPONSE
+   * @throws {MyQError} DEVICE_NOT_FOUND
+   */
+  public getDevice(serialNumber: string): Promise<DeviceResponse>;
+
+  /**
+   * Check whether a door on the myQ account is open or closed.
+   *
+   * login() must be called before this.
+   *
+   * Note that this can report back intermediary states between open and closed as well.
+   *
+   * @param {string} serialNumber Serial number of door
+   * @returns {DeviceStateResponse} containing a success code and the state of the door
+   * @throws {MyQError} INVALID_ARGUMENT
+   * @throws {MyQError} LOGIN_REQUIRED
+   * @throws {MyQError} SERVICE_REQUEST_FAILED
+   * @throws {MyQError} SERVICE_UNREACHABLE
+   * @throws {MyQError} INVALID_SERVICE_RESPONSE
+   * @throws {MyQError} DEVICE_NOT_FOUND
+   * @throws {MyQError} INVALID_DEVICE
+   */
+  public getDoorState(serialNumber: string): Promise<DeviceStateResponse>;
+
+  /**
+   * Open or close a door on the myQ account.
+   *
+   * login() must be called before this.
+   *
+   * @param {string} serialNumber Serial number of door
+   * @param {Symbol} action Action from MyQ.actions.door to request on door
+   * @returns {DeviceSetStateResponse} containing a success code
+   * @throws {MyQError} INVALID_ARGUMENT
+   * @throws {MyQError} LOGIN_REQUIRED
+   * @throws {MyQError} SERVICE_REQUEST_FAILED
+   * @throws {MyQError} SERVICE_UNREACHABLE
+   * @throws {MyQError} INVALID_SERVICE_RESPONSE
+   * @throws {MyQError} DEVICE_NOT_FOUND
+   * @throws {MyQError} INVALID_DEVICE
+   */
+  public setDoorState(
+    serialNumber: string,
+    action: Symbol
+  ): Promise<DeviceSetStateResponse>;
+
+  /**
+   * Check whether a light on the myQ account is turned on or turned off.
+   *
+   * login() must be called before this.
+   *
+   * @param {string} serialNumber Serial number of light
+   * @returns {DeviceStateResponse} containing a success code and the state of the light
+   * @throws {MyQError} INVALID_ARGUMENT
+   * @throws {MyQError} LOGIN_REQUIRED
+   * @throws {MyQError} SERVICE_REQUEST_FAILED
+   * @throws {MyQError} SERVICE_UNREACHABLE
+   * @throws {MyQError} INVALID_SERVICE_RESPONSE
+   * @throws {MyQError} DEVICE_NOT_FOUND
+   * @throws {MyQError} INVALID_DEVICE
+   */
+  public getLightState(
+    serialNumber: string
+  ): Promise<DeviceStateResponse>;
+
+  /**
+   * Turn on or turn off a light on the myQ account.
+   *
+   * login() must be called before this.
+   *
+   * @param {string} serialNumber Serial number of light
+   * @param {Symbol} action Action from MyQ.actions.light to request on light
+   * @returns {DeviceSetStateResponse} containing a success code
+   * @throws {MyQError} INVALID_ARGUMENT
+   * @throws {MyQError} LOGIN_REQUIRED
+   * @throws {MyQError} SERVICE_REQUEST_FAILED
+   * @throws {MyQError} SERVICE_UNREACHABLE
+   * @throws {MyQError} INVALID_SERVICE_RESPONSE
+   * @throws {MyQError} DEVICE_NOT_FOUND
+   * @throws {MyQError} INVALID_DEVICE
+   */
+  public setLightState(
+    serialNumber: string,
+    action: Symbol
+  ): Promise<DeviceSetStateResponse>;
+}

--- a/types/MyQError.d.ts
+++ b/types/MyQError.d.ts
@@ -1,0 +1,7 @@
+export default class MyQError {
+  public code: number;
+  public message: string;
+  public name: string;
+  public stack: string;
+  public toString(): string;
+}

--- a/types/actions.d.ts
+++ b/types/actions.d.ts
@@ -1,0 +1,12 @@
+declare const actions: {
+  door: {
+    OPEN: Symbol;
+    CLOSE: Symbol;
+  };
+  light: {
+    TURN_ON: Symbol;
+    TURN_OFF: Symbol;
+  };
+};
+
+export default actions;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,9 @@
+import MyQ from './MyQ';
+import actions from './actions';
+import MyQError from '../src/MyQError';
+import type * as types from './types';
+
+declare module 'myq-api' {
+  export default MyQ;
+  export { types, MyQError, actions };
+}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,0 +1,91 @@
+export type Code =
+  | 'OK'
+  | 'ERR_MYQ_INVALID_ARGUMENT'
+  | 'ERR_MYQ_LOGIN_REQUIRED'
+  | 'ERR_MYQ_AUTHENTICATION_FAILED'
+  | 'ERR_MYQ_AUTHENTICATION_FAILED_ONE_TRY_LEFT'
+  | 'ERR_MYQ_AUTHENTICATION_FAILED_LOCKED_OUT'
+  | 'ERR_MYQ_DEVICE_NOT_FOUND'
+  | 'ERR_MYQ_DEVICE_STATE_NOT_FOUND'
+  | 'ERR_MYQ_INVALID_DEVICE'
+  | 'ERR_MYQ_SERVICE_REQUEST_FAILED'
+  | 'ERR_MYQ_SERVICE_UNREACHABLE'
+  | 'ERR_MYQ_INVALID_SERVICE_RESPONSE';
+
+export interface Device {
+  href: string;
+  serial_number: string;
+  device_family: string;
+  device_platform: string;
+  device_type: string;
+  name: string;
+  parent_device?: string;
+  parent_device_id?: string;
+  created_date: string;
+  state: DeviceState;
+}
+
+export interface DeviceState {
+  dps_low_battery_mode?: boolean;
+  monitor_only_mode?: boolean;
+  number_of_learned_dps_devices?: number;
+  sensor_comm_error?: boolean;
+  door_state?: string;
+  open?: string;
+  close?: string;
+  last_update?: string;
+  passthrough_interval?: string;
+  door_ajar_interval?: string;
+  invalid_credential_window?: string;
+  invalid_shutout_period?: string;
+  is_unattended_open_allowed?: boolean;
+  is_unattended_close_allowed?: boolean;
+  aux_relay_delay?: string;
+  use_aux_relay?: boolean;
+  aux_relay_behavior?: string;
+  rex_fires_door?: boolean;
+  command_channel_report_status?: boolean;
+  control_from_browser?: boolean;
+  report_forced?: boolean;
+  report_ajar?: boolean;
+  max_invalid_attempts?: number;
+  online: boolean;
+  last_status: string;
+  firmware_version?: string;
+  homekit_capable?: boolean;
+  homekit_enabled?: boolean;
+  learn?: string;
+  learn_mode?: boolean;
+  updated_date?: string;
+  physical_devices?: string[];
+  pending_bootload_abandoned?: boolean;
+}
+
+export interface LoginResponse {
+  code: Code;
+  securityToken: string;
+}
+
+export interface DevicesResponse {
+  code: string;
+  devices: Device[];
+}
+
+export interface DeviceResponse {
+  code: string;
+  devices: Device;
+}
+
+export interface DeviceStateResponse {
+  code: string;
+  deviceState: DeviceState;
+}
+
+export interface DeviceSetStateResponse {
+  code: string;
+}
+
+export interface LightStateResponse {
+  code: string;
+  lightState: LightState;
+}


### PR DESCRIPTION
Fix for #26

This PR adds type declarations for `MyQ` class, `actions` object, and `MyQError` class.

## Typescript usage:

```typescript
import MyQ, { actions } from 'myq-api';

async function main() {
  const account = new MyQ();
  await account.login('username', 'password');
  const devices = (await account.getDevices()).devices;
  await account.setDoorState(devices[0].serial_number, actions.door.CLOSE);
}

main();
```

You will need to add `"esModuleInterop": true` to `tsconfig.json`.
This is due to `MyQ` class being a default export (see `import MyQ, { actions } from 'myq-api';`).
I think if we were to fully port this to TypeScript, the `MyQ` would have to be changed to a regular export (maybe called `Client`) to work well with new ES modules/TypeScript but that would be a BREAKING change.

Light device state response typings might not be correct (I don't have a device with a light to see the api response)